### PR TITLE
Move exit_if early in consumer_loop

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -244,6 +244,11 @@ module Kafka
     # @return [nil]
     def each_batch(min_bytes: 1, max_wait_time: 1, automatically_mark_as_processed: true, exit_if: nil)
       consumer_loop do
+        if exit_if && exit_if.call
+          @running = false
+          break
+        end
+
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
         batches.each do |batch|

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", "~> 3.0"
   spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "timecop"


### PR DESCRIPTION
While debugging our Kafka Consumer Jobs, I realized that `exit_if` is never called if `fetch_batches` raises an Exception, and instead it keeps running in a never terminating loop.
This PR moves `exit_if` check as the first thing we do before we fetch anything and makes sure we exit when the condition is met.

```
$ bundle exec rspec
....
Finished in 10.86 seconds (files took 0.37654 seconds to load)
97 examples, 0 failures
```


cc: @Shopify/resiliency 